### PR TITLE
Missing server name in config is causing rp.name to be null during registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passwordlessdev/passwordless-client",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "main": "dist/esm/passwordless.mjs",
   "types": "dist/passwordless.d.ts",
   "type": "module",

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -12,6 +12,7 @@ export interface Config {
     apiKey: string;
     origin: string;
     rpid: string;
+    serverName: string;
 }
 
 export class Client {
@@ -20,7 +21,8 @@ export class Client {
         apiKey: '',
         origin: window.location.origin,
         rpid: window.location.hostname,
-    }
+        serverName: 'Passwordless.dev'
+    };
     private abortController: AbortController = new AbortController();
 
     constructor(config: AtLeast<Config, 'apiKey'>) {
@@ -148,6 +150,7 @@ export class Client {
                 token,
                 RPID: this.config.rpid,
                 Origin: this.config.origin,
+                ServerName: this.config.serverName
             }),
         });
 


### PR DESCRIPTION
- This will fix an issue related to being unable to register passkeys with 1Password.